### PR TITLE
use eval for setting active docker machine

### DIFF
--- a/docker/docker_compose_machine_swarm_cloud.html
+++ b/docker/docker_compose_machine_swarm_cloud.html
@@ -750,7 +750,7 @@
              <p>
                Lets make the ec2 box active, which would be the box any docker or compose commands talk to.
              </p>
-             <code>docker-machine active ec2box;</code>
+             <code>eval $(docker-machine env ec2box);</code>
             <code>docker-machine ls</code>
             <code class="output">
               NAME   &nbsp;ACTIVE   DRIVER &nbsp;&nbsp;&nbsp;   &nbsp;STATE   &nbsp;  URL   


### PR DESCRIPTION
docker-machine active no longer takes a parameter. You need to eval the output of docker-machine env to set the active docker host.

This is for docker-machine 0.3.0