### PR TITLE
Fix spelling, grammar and punctuation mistakes

### DIFF
--- a/postfix/edition14.html
+++ b/postfix/edition14.html
@@ -116,7 +116,7 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 			<h5><a href="#install">Installation</a></h5>
 			<p>How to install all packages and which ones.</p>
 			<ul>
-				<li><p><a href="#install_distro">Distrobution</a></p></li>
+				<li><p><a href="#install_distro">Distribution</a></p></li>
 				<li><p><a href="#install_base">Base Install</a></p></li>
 				<li><p><a href="#install_repos">Repositories</a></p></li>
 				<li><p><a href="#install_pack">Packages</a></p></li>
@@ -141,7 +141,7 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 				</li>
 				<li><p><a href="#config-adv-content">Content Checks (amivisd-new)</a></p>
 					<ul>
-						<li><p><a href="#config-adv-spam">Anti-Spam(SpamAssassin)</a></p></li>
+						<li><p><a href="#config-adv-spam">Anti-Spam (SpamAssassin)</a></p></li>
 						<li><p><a href="#config-adv-virus">Anti-Virus (ClamAV)</a></p></li>
 						<li><p><a href="#config-adv-policy">Policy Check (PostGrey)</a></p></li>
 					</ul>
@@ -182,7 +182,7 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 		<li>
 			<h5><a href="#initialize">Initialize</a></h5>
 			<p>
-				If receiving an already setup machine,
+				If receiving an already set up machine,
 				a list of actions to do to initialize and configure it.
 			</p>
 		</li>
@@ -237,7 +237,7 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 			</p>
 			<ul>
 				<li><p><a href="#ec2">Impressions of EC2</a></p></li>
-				<li><p><a href="#ec2_tips">ec2 introduction, tips and hwotos</a></p></li>
+				<li><p><a href="#ec2_tips">ec2 introduction, tips and howtos</a></p></li>
 				<li><p><a href="#ec2_use">Using EC2 with this howto</a></p></li>
 				<li><p><a href="#ec2_vagrant">Vagrant</a></p></li>
 				<!-- <li><p><a href="#ec2_ami">Amazon EC2 Images: AMIs</a></p></li> -->
@@ -507,7 +507,7 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 		or via web mail.
 	</p>
 	<p>
-		It is secure, traffic can encrypted
+		It is secure, traffic can be encrypted
 		and it will block virtually all spam and viruses.
 	</p>
 	<h6><a href="#top">Return to top</a>.</h6>
@@ -516,7 +516,7 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 	<h3>Research</h3>
 	<p>
 		Don't take my word for it!
-		Research others opinions and methods.
+		Research other opinions and methods.
 		Look at my <a href="#references">references</a>,
 		look at <a href="http://www.postfix.org/docs.html"
 			>Postfix.org's howtos</a>,
@@ -675,7 +675,7 @@ y8JYIMG1EKR9YeTQVLalcV2nYjRM/0GXuj0O
 	<div style="float: right;">
 		<a href="http://www.ubuntu.com"><img
 			src="edition3/images/ubuntu-Logo-small.png"
-			alt="Ubuntu" title="Ubuntu Linix OS"
+			alt="Ubuntu" title="Ubuntu Linux OS"
 			width="120" class="postfix" /></a><br />
 		<a href="http://www.postfix.org"><img
 			src="edition3/images/mysza.gif"
@@ -732,7 +732,7 @@ y8JYIMG1EKR9YeTQVLalcV2nYjRM/0GXuj0O
 	</div>
 
 	<h4>
-		What software packages have/will I use and why.
+		What software packages did/will I use and why.
 	</h4>
 	<ul>
 		<li>
@@ -740,8 +740,8 @@ y8JYIMG1EKR9YeTQVLalcV2nYjRM/0GXuj0O
 			<h6><a href="http://www.ubuntu.com">www.ubuntu.com</a></h6>
 			<p>
 				Ah the age old distro argument...
-				Thankfully this set up should work on most distros.
-				I used to base this howto on Mandrake(now Mandriva),
+				Thankfully this setup should work on most distros.
+				I used to base this howto on Mandrake (now Mandriva),
 				and I started this new edition on a Gentoo box.
 				But I don't have the patience for Gentoo,
 				nor the money to stay with Mandriva Power editions.
@@ -760,7 +760,7 @@ y8JYIMG1EKR9YeTQVLalcV2nYjRM/0GXuj0O
 				Yup I am a sucker for anything that works easily.
 				Postfix is powerful, well established,
 				but not too bloated,
-				and is security concious from the start.
+				and is security conscious from the start.
 			</p>
 		</li>
 		<li>
@@ -821,8 +821,8 @@ y8JYIMG1EKR9YeTQVLalcV2nYjRM/0GXuj0O
 			<p>
 				Postgrey is an excellent little script to stop 99% of all spam.
 				All it does is on first contact for specific from-to combinations,
-				tells the sender server to try again in a little while,
-				which most spammers cant afford to do.
+				tell the sender server to try again in a little while,
+				which most spammers can't afford to do.
 				When proper servers try again after a few minutes it lets it through.
 			</p>
 		</li>
@@ -832,7 +832,7 @@ y8JYIMG1EKR9YeTQVLalcV2nYjRM/0GXuj0O
 			<p>
 				Secure and trusted cryptography technology
 				for encryption of SMTP traffic.
-				Not too be confused with client encryption technology
+				Not to be confused with client encryption technology
 				like GnuPG and S/MIME. They are covered in the
 				<a href="#extend">extend</a> section.
 				Formerly referenced as SSL.
@@ -864,7 +864,7 @@ y8JYIMG1EKR9YeTQVLalcV2nYjRM/0GXuj0O
 	</ul>
 		<p>
 			Please see <a href="edition5.html#app_links">software links appendix</a> for further information
-			about these software packages. In that section there is more links to
+			about these software packages. In that section there are more links to
 			documentation or forums, and viable alternatives, downloadable packages, versions details etc.
 		</p><p>
 			Further software and tweaks are discussed in the
@@ -893,7 +893,7 @@ y8JYIMG1EKR9YeTQVLalcV2nYjRM/0GXuj0O
 	-->
 
 	<ul>
-		<li><p><a href="#install_distro">Distrobution</a></p></li>
+		<li><p><a href="#install_distro">Distribution</a></p></li>
 		<li><p><a href="#install_Base">Base Install</a></p></li>
 		<li><p><a href="#install_repos">Repositories</a></p></li>
 		<li><p><a href="#install_pack">Packages</a></p></li>
@@ -911,23 +911,23 @@ y8JYIMG1EKR9YeTQVLalcV2nYjRM/0GXuj0O
 		Therefore this section uses apt packages to its fullest.
 	</p>
 	<p>
-		For other installation method please refer to previous edition's
+		For other installation methods please refer to previous edition's
 		<a href="http://flurdy.com/docs/postfix/edition5.html#app_links">software links</a>
 		and your own distribution
-		for the documention for other ways of installing.
-		My <a href="edition2.html">2nd edition</a>(outdated) has instructions
+		for the documentation for other ways of installing.
+		My <a href="edition2.html">2nd edition</a> (outdated) has instructions
 		for Mandriva, general RPM and tarball compiling.
 	</p>
 	<p>
 		To follow the rest of this howto with another distribution,
 		you need to ensure all your
 		packages have been installed with the same modules,
-		E.g MySQL lookup on postfix and sasl, php in apache etc.
+		i.e. MySQL lookup on postfix and sasl, php in apache etc.
 	</p>
 	<p>
 		I have set up mail servers using the 32bit and 64bit x86 platforms,
-		and if all the packages are available then other,
-		E.g. Mac platforms should work too.
+		and if all the packages are available then other platforms,
+		e.g. Mac, should work too.
 	</p>
 
 	<a name="install_base"></a>
@@ -947,7 +947,7 @@ y8JYIMG1EKR9YeTQVLalcV2nYjRM/0GXuj0O
 	</p>
 
 	<p>
-		Ps. Please note that after a while Ill stop specifying the use of <a href="http://help.ubuntu.com/community/RootSudo">sudo</a>,
+		P.S. Please note that after a while I'll stop specifying the use of <a href="http://help.ubuntu.com/community/RootSudo">sudo</a>,
 		as it is up to yourselves if you use it or use a privileged user, e.g. root. My advice is to use 'sudo'.
 	</p>
 
@@ -963,7 +963,7 @@ y8JYIMG1EKR9YeTQVLalcV2nYjRM/0GXuj0O
 		discussed repository configuration in more detail.
 	</p> -->
 	<p>
-		I would recommend find a <a href="https://launchpad.net/ubuntu/+archivemirrors">repository archive</a> close to your server's location.
+		I would recommend to find a <a href="https://launchpad.net/ubuntu/+archivemirrors">repository archive</a> close to your server's location.
 		For example a country specific one or if hosted on <i>AWS EC2</i> an archive in your AWS region.
 		Remember these are highly security sensitive so choose one you trust.
 	</p>
@@ -981,7 +981,7 @@ deb http://<i>eu-west-1.ec2</i>.archive.ubuntu.com/ubuntu/ trusty-updates univer
 deb-src http://<i>eu-west-1.ec2</i>.archive.ubuntu.com/ubuntu/ trusty-updates universe</code>
 		<code>deb http://security.ubuntu.com/ubuntu trusty-security universe
 deb-src http://security.ubuntu.com/ubuntu trusty-security universe</code>
-		Note the <i>security</i> repository always have to go to the non-mirrored server.
+		Note the <i>security</i> repository always has to go to the non-mirrored server.
 	</p>
 	<p>
 		As mentioned in the <a href="edition5.html#install_repos">previous edition</a>
@@ -1017,9 +1017,9 @@ sudo apt-get upgrade</code>
 	<h5>Additional packages</h5>
 	<p>
 		I also install a few other packages that I personally prefer.
-		But nothing todo with the mail server.
+		But they have nothing to do with the mail server.
 		<code>sudo apt-get install vim lynx curl git</code>
-		<a href="http://www.mutt.org/">Mutt</a> is a very usefull command line mail client that I always install
+		<a href="http://www.mutt.org/">Mutt</a> is a very useful command line mail client that I always install
 		but I usually do that at the end when testing so that it doesn't
 		install its dependency on Postfix before I am ready.
 		<code>sudo apt-get install mutt</code>
@@ -1089,7 +1089,7 @@ sudo apt-get upgrade</code>
 			<ul>
 				<li><p><a href="#config-adv-content">Content Checks (amivisd-new)</a></p>
 					<ul>
-						<li><p><a href="#config-adv-spam">Anti-Spam(SpamAssassin)</a></p></li>
+						<li><p><a href="#config-adv-spam">Anti-Spam (SpamAssassin)</a></p></li>
 						<li><p><a href="#config-adv-virus">Anti-Virus (ClamAV)</a></p></li>
 						<li><p><a href="#config-adv-policy">Policy Check (PostGrey)</a></p></li>
 					</ul>
@@ -1119,7 +1119,7 @@ sudo apt-get upgrade</code>
 	<a name="config-simple"></a>
 	<h3>Simple mail server</h3>
 	<p>
-		Now lets configure a simple mail server using some of
+		Now let's configure a simple mail server using some of
 		the packages installed.
 	</p>
 
@@ -1158,14 +1158,14 @@ sudo apt-get upgrade</code>
 	</p>
 	<h5>SSH only</h5>
 	<p>
-		By default Shorewall in Ubuntu has an empty set up.
+		By default Shorewall in Ubuntu has an empty setup.
 		You can find the default values for Shorewall in
 		<i>/usr/share/shorewall/configfiles</i>.
 		And examples in <i>/usr/share/doc/shorewall/examples</i>.
-		We will create a basic set up.
+		We will create a basic setup.
 	</p>
 	<p>
-		First configure which network adapters we are accessing the net.
+		First configure which network adapters are accessing the net.
 		<code>sudo cp /usr/share/doc/shorewall/examples/one-interface/interfaces /etc/shorewall/;
 sudo vi /etc/shorewall/interfaces</code>
 		<code class="document"><span class="comment"># If not using sub set hosts replace the zone <em>-</em> with <em>net</em></span>
@@ -1174,7 +1174,7 @@ sudo vi /etc/shorewall/interfaces</code>
 -     eth0            detect          dhcp,tcpflags,logmartians,nosmurfs,sourceroute=0</code>
 	</p>
 	<p>
-		Then we will configure network zones
+		Then we will configure network zones.
 		<code>sudo cp /usr/share/doc/shorewall/examples/one-interface/zones /etc/shorewall/;
 sudo vi /etc/shorewall/zones</code>
 		Add the firewall if not there and the internet as a zone, and the optional VPC if you need one.
@@ -1184,7 +1184,7 @@ vpc:net     ipv4</code>
 	</p>
 	<p>
 		Then if needed, specify hosts in a <em>hosts</em> file.
-		E.g. If you want to specify what is your home IP etc.
+		E.g. if you want to specify what is your home IP etc.
       or define a subset as a DMZ or VPC.
       <code>sudo vi /etc/shorewall/hosts</code>
 		<code class="document"><span class="comment">#ZONE     HOST(S)                     OPTIONS</span>
@@ -1304,7 +1304,7 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 		<code>sudo apt-get install mysql-client mysql-server</code>
 		This will prompt you for a root password.
 		Choose something wise and remember it!
-		For purpose of this tutorial I will set it to <b><i>rootPASSWORD</i></b>
+		For the purpose of this tutorial I will set it to <b><i>rootPASSWORD</i></b>
 	</p>
 
 	<h5>Configuration</h5>
@@ -1390,7 +1390,7 @@ UNIQUE KEY `id` (`id`)
 ) ;</code>
 
 
-	<code><span class="comment"># To visualise the tables created:</span>
+	<code><span class="comment"># To visualize the tables created:</span>
 describe aliases; describe domains; describe users;
 <span class="comment"># then quit mysql</span>
 exit;</code>
@@ -1401,7 +1401,7 @@ exit;</code>
 		In Mandrake I had to manually create a blank one in /etc.
 		But we need to configure it, so:
 		<code>sudo vi /etc/mysql/my.cnf</code>
-		In previous version you needed to comment out this line
+		In previous versions you needed to comment out this line
 		<code class="document"><span class="comment">#skip-networking</span></code>
 		However in today's file the default is to bind the
 		address to localhost, which is fine.
@@ -1415,7 +1415,7 @@ general_log = 1</code>
 	</p>
 
 	<p>
-		Restart MySQL to make sure its picking up the new settings.
+		Restart MySQL to make sure it's picking up the new settings.
 		<code>sudo /etc/init.d/mysql restart</code>
 	</p>
 	<h6><a href="#top">Return to top</a>.</h6>
@@ -1429,8 +1429,8 @@ general_log = 1</code>
 	<h5>Installation</h5>
 	<p>
 		<code>sudo apt-get install postfix postfix-mysql</code>
-		This will prompt you to choose type of email server.
-		Select <b><i>internet site</i></b>
+		This will prompt you to choose the type of mail server.
+		Select <b><i>internet site</i></b>.
 		It will also  suggest a server name. Correct this if needed.
 	</p>
 	<h5>Configuration</h5>
@@ -1441,9 +1441,9 @@ general_log = 1</code>
 		where domain name obviously is replaced with your domain name.
 	</p>
 	<p>
-		Now will open the main postfix configuration file:
+		Now we will open the main postfix configuration file:
 		<code>sudo vi /etc/postfix/main.cf</code>
-		Debian and Ubuntu already puts in some sensible default values in this file.
+		Debian and Ubuntu already put some sensible default values in this file.
 		You may need to comment some of them out if we put the same in as well.
 	</p>
 
@@ -1459,7 +1459,7 @@ myorigin=<i>example.com</i></code>
 	<p>
 		Then decide what the greeting text will be.
 		Enough info so it is useful,
-		but not divulge everything to potential hackers.
+		but do not divulge everything to potential hackers.
 		<code class="document">smtpd_banner = $myhostname ESMTP $mail_name</code>
 	</p>
 	<p>
@@ -1468,7 +1468,7 @@ myorigin=<i>example.com</i></code>
 		or send them yourself.
 		I sometimes send via my ISP's server,
 		so it has to worry about the queuing etc.
-		If you send it yourself then you are not reliant on 3rd party server.
+		If you send it yourself then you are not reliant on a 3rd party server.
 		But you may risk more exposure and
 		accidentally be blocked by spam blockers.
 		And it is more work for your server.
@@ -1515,7 +1515,7 @@ mydestination =</code>
 
 	</p>
 	<p>
-		Then will set a few numbers.
+		Then we will set a few numbers.
 
 		<code class="document"><span class="comment"># how long if undelivered before sending warning update to sender		</span>
 delay_warning_time = 4h
@@ -1523,14 +1523,14 @@ delay_warning_time = 4h
 unknown_local_recipient_reject_code = 450
 <span class="comment"># how long to keep message on queue before return as failed.</span>
 <span class="comment"># some have 3 days, I have 16 days as I am backup server for some people</span>
-<span class="comment"># whom go on holiday with their server switched off.</span>
+<span class="comment"># who go on holiday with their server switched off.</span>
 maximal_queue_lifetime = 7d
 <span class="comment"># max and min time in seconds between retries if connection failed</span>
 minimal_backoff_time = 1000s
 maximal_backoff_time = 8000s
 <span class="comment"># how long to wait when servers connect before receiving rest of data</span>
 smtp_helo_timeout = 60s
-<span class="comment"># how many address can be used in one message.</span>
+<span class="comment"># how many addresses can be used in one message.</span>
 <span class="comment"># effective stopper to mass spammers, accidental copy in whole address list</span>
 <span class="comment"># but may restrict intentional mail shots.</span>
 smtpd_recipient_limit = 16
@@ -1590,7 +1590,7 @@ virtual_mailbox_domains = mysql:/etc/postfix/mysql_domains.cf
 
 	<p>
 		You can (as in my older editions) use a lookup for the uid and gid of the owner of mail files.
-		But I tend to have one owner(virtual), so instead add this:
+		But I tend to have one owner (virtual), so instead add this:
 		<code class="document">virtual_uid_maps = static:5000
 virtual_gid_maps = static:5000</code>
 	</p>
@@ -1611,7 +1611,7 @@ sudo postalias /etc/postfix/aliases</code>
 		Next you need to set up the folder
 		where the virtual mail will be stored.
 		This may have already been done by the apt-get.
-		And also create the user whom will own the folders.
+		And also create the user who will own the folders.
 
 	<code><span class="comment"># to add if there is not a virtual user</span>
 sudo mkdir /var/spool/mail/virtual
@@ -1634,7 +1634,7 @@ sudo chown -R virtual:virtual /var/spool/mail/virtual</code>
 		We will only set up a few now, and the rest later when/if needed:
 	</p>
 
-	<p>Edit(create) how to find the users mailbox location
+	<p>Edit (create) how to find the users mailbox location
 	<code>sudo vi /etc/postfix/mysql_mailbox.cf</code></p>
 	<code class="document">user=mail
 password=<i>mailPASSWORD</i>
@@ -1784,7 +1784,7 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 		<code class="document">MYSQL_WHERE_CLAUSE enabled=1</code>
 	</p>
 	<p>
-		Lastly you can have a look at the imapd file, but no changes is needed.
+		Lastly you can have a look at the imapd file, but no change is needed.
 		<code>vi /etc/courier/imapd</code>
 	</p>
 	<p>
@@ -1823,10 +1823,10 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 		<p>
 		<ul>
 			<li><p>Insert stub data from <a href="#data">data section</a></p></li>
-			<li><p>Apply advice from <a href="#test">test section</a> judicously</p></li>
+			<li><p>Apply advice from <a href="#test">test section</a> judiciously</p></li>
 			<li><p>Ensure the mail server can receive email correctly first, then try sending.</p></li>
 			<li><p>Once you are positive the mail has been received, the mail folders have been automatically created,<br/>
-			 only then you should test if you can actually read the emails before proceding</p></li>
+			 only then you should test if you can actually read the emails before proceeding.</p></li>
 		</ul>
 
 <!--
@@ -1865,8 +1865,8 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 	<a name="config-adv"></a>
 	<h3>Advanced mail server</h3>
 	<p>
-		Now lets extend this setup with more useful content checks
-		, security and user interfaces.
+		Now let's extend this setup with more useful content checks,
+		security and user interfaces.
 	</p>
 
 
@@ -1899,20 +1899,20 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 		All of amavis' configuration files are in <i>/etc/amavisd</i>.
 		They are now spread across several files in <i>conf.d</i>.
 		Debian and Ubuntu defaults are now very sensible and spread into
-		seperate files.
+		separate files.
 		<code>cd /etc/amavis/conf.d</code>
 	</p>
 	<p>
 		<b><i>01-debian</i></b> defaults are fine.<br />
 	</p>
 	<p>
-		Have a look at <code>less 05-domain_id</code> but dont change anything in it.
+		Have a look at <code>less 05-domain_id</code> but don't change anything in it.
 	</p>
 	<p>
-		Have a look at <code>less 05-node_id</code> but dont change anything in it.
+		Have a look at <code>less 05-node_id</code> but don't change anything in it.
 	</p>
 	<p>
-		Have a look at <code>less 15-av_scanners</code> but dont change anything in it.
+		Have a look at <code>less 15-av_scanners</code> but don't change anything in it.
 	</p>
 	<p>
 		Edit content check file
@@ -1924,7 +1924,7 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 #   \%bypass_spam_checks, \@bypass_spam_checks_acl, \$bypass_spam_checks_re);</span></code>
 	</p>
 	<p>
-		Have a look at <code>less 20-debian_defaults</code> and <code>less 21-ubuntu_defaults</code> but dont change anything in them.
+		Have a look at <code>less 20-debian_defaults</code> and <code>less 21-ubuntu_defaults</code> but don't change anything in them.
 	</p>
 	<p>
 		<b><i>25-amavis_helpers</i></b> defaults are fine.<br />
@@ -1950,8 +1950,8 @@ $final_spam_destiny = D_PASS;
 	</p>
 
 	<p>
-		We have now setup amavis to scan and pass along incomming email.
-		Next we will setup postfix to talk to amavis.
+		We have now set up amavis to scan and pass along incomming email.
+		Next we will set up postfix to talk to amavis.
 	</p>
 
 	<p>
@@ -2037,7 +2037,7 @@ $final_spam_destiny = D_DISCARD; <span class="comment"># ubuntu default, recomme
 	</p>
 	<p>
 		The default config of spam assassin is okay.
-		You could refer to <a href="edition5.html#spam">previous edition</a>
+		You could refer to a <a href="edition5.html#spam">previous edition</a>
 		for more configuration options.
 	</p>
 	<p>
@@ -2121,9 +2121,9 @@ $final_spam_destiny = D_DISCARD; <span class="comment"># ubuntu default, recomme
 
 	<div class="note">
 	<p>
-		You know have an advanced mail server.
-		You can use this, but Id recommend continuing.
-		However this is a good point to <a href="#test">test</a> the set up so far
+		You now have an advanced mail server.
+		You can use this, but I'd recommend continuing.
+		However this is a good point to <a href="#test">test</a> the setup so far
 		and to insert some <a href="#data">data</a> in the db.
 	</p>
 	</div>
@@ -2171,13 +2171,13 @@ $final_spam_destiny = D_DISCARD; <span class="comment"># ubuntu default, recomme
 	<a name="config-secure-sasl"></a>
 	<h3>Authentication</h3>
 	<p>
-		Normal email traffic between clients and servers are in open plain text.
+		Normal email traffic between clients and servers is in open plain text.
 		That includes passwords and content of emails.
 	</p>
 	<h5>SASL</h5>
 	<p>
 		SASL secures the actual authentication (login),
-		by encoding the passwords so that it can not be easily intercepted.
+		by encoding the passwords so that it cannot be easily intercepted.
 		The rest of the emails are however in clear plain text.
 	</p>
 	<p>
@@ -2189,7 +2189,7 @@ $final_spam_destiny = D_DISCARD; <span class="comment"># ubuntu default, recomme
 	</p>
 	<p>
 		Obviously this is not ideal, so there are ways to combine SASL and storing encrypted passwords.
-		In the future the packages that comes with Ubuntu may support the
+		In the future the packages that come with Ubuntu may support the
 		<a href="http://ubuntuforums.org/showthread.php?t=259862">password_format</a>
 		configuration option for SASL.
 		But until then you can configure SASL to ask PAM to compare the passwords:
@@ -2262,10 +2262,10 @@ sql_select: select crypt from users where id='%u@%r' and enabled = 1</code>
 		(<em>Note</em>: While <em>sql_passw</em> is the original parameter name (without the <em>d</em>), a more obvious <em>sql_passwd</em> will also work in later versions)</p>
 
 	<p>
-		Tell the pam how to to authenticate smtp via mysql:
+		Tell pam how to to authenticate smtp via mysql:
 	</p>
 	<code>sudo vi /etc/pam.d/smtp</code>
-	<p>These must be on 2 lines only, but I have broken them up for easier to read.</p>
+	<p>These must be on 2 lines only, but I have broken them up for easier reading.</p>
 	<code class="document">auth required pam_mysql.so user=mail passwd=<i>mailPASSWORD</i>
 			host=127.0.0.1 db=maildb table=users usercolumn=id passwdcolumn=crypt crypt=1
 account sufficient pam_mysql.so user=mail passwd=<i>mailPASSWORD</i>
@@ -2273,7 +2273,7 @@ account sufficient pam_mysql.so user=mail passwd=<i>mailPASSWORD</i>
 
 	<p>
 		In addition to tailing <i>var/log/mail.log</i> and <i>/var/log/mysql/mysql.log</i>
-		it is quite usefull to tail the auth.log as well when testing SASL.
+		it is quite useful to tail the auth.log as well when testing SASL.
 	</p>
 	<code>tail -f /var/log/auth.log</code>
 
@@ -2294,7 +2294,7 @@ sudo /etc/init.d/postfix restart</code>
 	</p>
 	<code>sudo vi /etc/courier/imapd</code>
 	<p>
-		This may already be avaiable as a commented out line.
+		This may already be available as a commented out line.
 		If not replace the current line by adding UTH=CRAM-MD5 AUTH=CRAM-SHA1 so it resembles something like this:
 		(Again on one line)
 	</p>
@@ -2313,7 +2313,7 @@ sudo /etc/init.d/courier-imap-ssl restart</code>
 	<h3>Encryption</h3>
 	<h5>TLS</h5>
 	<p>
-		Encrypting the traffic stops anyone else listening in on your email communications.
+		Encrypting the traffic stops anyone else from listening in on your email communications.
 		And is very recommended. There are different types of communication to encrypt:
 		The data traffic between your email applications and the server when you read emails
 		or when you send emails,
@@ -2360,15 +2360,15 @@ smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt</code>
 		But I prefer to enable <i>submission</i> (port 587),
 		so that clients can use it, and I can restrict them to TLS only.
 		Also enabled <i>smtps</i> service (port 465),
-		for some compatebility with some older clients (outlook express etc).
+		for some compatibility with some older clients (outlook express etc).
 	</p>
 	<code class="document">submission inet n       -       n       -       -       smtpd
   -o smtpd_sasl_auth_enable=yes
-<span class="comment"># if you do not want to restrict it encryption only, comment out next line</span><
+<span class="comment"># if you do not want to restrict it encryption only, comment out next line</span>
   -o smtpd_tls_auth_only=yes
 <span class="comment"># -o smtpd_tls_security_level=encrypt
 #  -o header_checks=
-#  -o body_checks=</span><
+#  -o body_checks=</span>
   -o smtpd_client_restrictions=permit_sasl_authenticated,reject_unauth_destination,reject
   -o smtpd_sasl_security_options=noanonymous,noplaintext
   -o smtpd_sasl_tls_security_options=noanonymous
@@ -2407,7 +2407,7 @@ openssl req -x509 -newkey rsa:1024 -keyout imapd.pem \
 
 	<p>
 		For maximum compatibility it is not wise to restrict to TLS only for the traffic between servers. As this means not all valid emails sent by others can reach your server.
-		However enabling them the option to encrypt is a good idea.
+		However enabling the option to encrypt is a good idea.
 	</p>
 	<p>
 		Be aware that the emails are not encrypted on your machine, nor on the server.
@@ -2418,7 +2418,7 @@ openssl req -x509 -newkey rsa:1024 -keyout imapd.pem \
 		In some situations SASL and TLS do not play well together.
 		Those situations are in combinations of storing encrypted passwords,
 		using MD5 authentication over encrypted traffic.
-		I recommend, insisting on TLS traffic with your authenticating clients,
+		I recommend insisting on TLS traffic with your authenticating clients,
 		which then negates the need for SASL.
 	</p>
 
@@ -2426,14 +2426,14 @@ openssl req -x509 -newkey rsa:1024 -keyout imapd.pem \
 	<h5>HTTPS</h5>
 
 	<p>
-		You probably also want to insist on https connections over tls if you below add webmail that are exposed to the public.
+		You probably also want to insist on https connections over tls if you below add webmail that is exposed to the public.
 		Securing a web server is out of scope for this howto, but will not be a lot different than the mail server tls settings.
 	</p>
 
 	<div class="note">
 	<p>
 		You know have an advanced secure mail server.
-		Now is another good point to <a href="#test">test</a> the set up so far
+		Now is another good point to <a href="#test">test</a> the setup so far
 		and to insert some <a href="#data">data</a> in the db.
 	</p>
 	</div>
@@ -2512,7 +2512,7 @@ $rcmail_config['smtp_helo_host'] = '<i>mail.example.com</i>';
 $rcmail_config['create_default_folders'] = TRUE;</code>
 	<p>There are other tweaks and security features you can enable such as:</p>
 	<code class="document">$rcmail_config['sendmail_delay'] = 1;</code>
-	<p>But perhaps concentrate on getting the basics working firtst...</p>
+	<p>But perhaps concentrate on getting the basics working first...</p>
 
 	<p>Save, exit and reload Apache to enable these aliases for Roundcube to work</p>
 	<code>sudo /etc/init.d/apache2 reload</code>
@@ -2520,7 +2520,7 @@ $rcmail_config['create_default_folders'] = TRUE;</code>
 		Then go to your roundcube installation depending where and how
 		you modified those Aliases, e.g. at
 		<i>http://mail.example.com/roundcube</i>.<br/>
-		That should be it
+		That should be it.
 	</p>
 
 	<p>If you have enabled session encryption then also enable the <i>mcrypt</i> library</p>
@@ -2546,7 +2546,7 @@ $rcmail_config['create_default_folders'] = TRUE;</code>
 		</li>
 		<li>
 			<p>
-				Or configure the <i>default_host</i> to
+				Or configure the <i>default_host</i> to a
 				different mail server depending on virtual host
 			</p>
 		</li>
@@ -2557,13 +2557,13 @@ $rcmail_config['create_default_folders'] = TRUE;</code>
 		</li>
 		<li>
 			<p>
-				Adding your own skin logo etc to customise the look is likely.
+				Adding your own skin logo etc to customize the look is likely.
 				<i>( $rcmail_config['skin_logo'] = 'yourlogo.png'; )</i>
 			</p>
 		</li>
 		<li>
 			<p>
-				If you webmail is not on the same server as your MTA (Postfix),
+				If your webmail is not on the same server as your MTA (Postfix),
 				then the MTA might not have the webmail server's IP listed in permit_mynetworks,
 				so you might want to log into the smtp when sending email:
 <code class="document">$rcmail_config['smtp_user'] = '%u';
@@ -2617,7 +2617,7 @@ $rcmail_config['smtp_auth_type'] = 'login';
 	-->
 	<p>
 		You may choose to restrict phpMyAdmin to a spefic virtual host.
-		If so you need to, edit
+		If so you need to edit
 		<code>sudo vi /etc/apache2/conf.d/phpmyadmin.conf</code>
 		and comment out the alias.
 		<code class="document"><span class="comment">#Alias /phpmyadmin /usr/share/phpmyadmin</span></code>
@@ -2641,16 +2641,16 @@ $rcmail_config['smtp_auth_type'] = 'login';
 	</p>
 	<p>
 		Further restrictions can be restricting to a specific virtual host.
-		Or renaming the folder. Purely ubfuscating, but simple.
+		Or renaming the folder. Purely obfuscating, but simple.
 	</p>
 	<p>
 		Or using the example in the webmail section,
 		and adding SSL requirement to the connection.
-		Or disabel mysql root's access via phpMyAdmin.
+		Or disable mysql root's access via phpMyAdmin.
 	</p>
 	<p>
-		Please refer to <a href="edition5.html#conf_admin">previous edition</a>
-		for example on htaccess, and mysql user restriction.
+		Please refer to a <a href="edition5.html#conf_admin">previous edition</a>
+		for an example on htaccess and mysql user restriction.
 	</p>
 	<h6><a href="#top">Return to top</a>.</h6>
 
@@ -2679,7 +2679,7 @@ $rcmail_config['smtp_auth_type'] = 'login';
 		You can also host your own DNS via packages such as <a href="http://www.isc.org/software/bind">Bind</a>.
 	</p>
 	<p>
-		Your provider might let you do this through a GUI, but in this is technically how a the configuration should look like:
+		Your provider might let you do this through a GUI, but this is technically what the configuration should look like:
 	</p>
 	<code><i>domain.tld</i>&nbsp;&nbsp;&nbsp;&nbsp;IN&nbsp;&nbsp;&nbsp;MX&nbsp;&nbsp;&nbsp;10&nbsp;&nbsp;&nbsp;<i>yourmailserver.domain.tld</i></code>
 	<p>
@@ -2694,7 +2694,7 @@ $rcmail_config['smtp_auth_type'] = 'login';
 		for a match between IP and mail server name, as part of their spam scoring.
 	</p>
 	<p>
-		If people need suggestions for domain registrars or dns providers then <a href="#contact">let me know</a>
+		If people need suggestions for domain registrars or dns providers then <a href="#contact">let me know</a>.
 	</p>
 	<br/>
 
@@ -2702,7 +2702,7 @@ $rcmail_config['smtp_auth_type'] = 'login';
 
 	<div class="note">
 	<p>
-		You know have a finished mail server.
+		You now have a finished mail server.
 		This is as far as the main guide goes.
 		Hope it was clear enough to follow.
 	</p>
@@ -2762,14 +2762,14 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 		<h3>Add users and domains</h3>
 			<p>
 				So we got a fully set up mail server...
-				Well no, there is no users, domains, no nothing!
+				Well no, there are no users, domains, no nothing!
 			</p>
 			<p>
-				Okay, first you need add some default data,
+				Okay, first you need to add some default data,
 				some which are required, some which make sense.
 			</p>
 			<p>
-				Then we'll add your own users and domains.
+				Then you will add your own users and domains.
 			</p>
 
 		<h4>Required domains and users</h4>
@@ -2823,7 +2823,7 @@ INSERT INTO domains (domain) VALUES
 
 		<h4>Domains and users</h4>
 		<p>
-			Now lets add some proper data.
+			Now let's add some proper data.
 		</p>
 		<p>
 			Say you want this machine to handle data for the fictional domains
@@ -2875,26 +2875,26 @@ INSERT INTO aliases (mail,destination) VALUES
 
 		<p>
 			So what does each of these lines actually do?
-			Well the domains are pretty straight forward.
+			Well the domains are pretty straightforward.
 		</p>
 		<p>
 			The users are as well, it requires four fields.
 			ID is the email address of the user, and also its username
-			when loggin in, described later on.
-			NAME is optional description of the user.
+			when logging in, described later on.
+			NAME is an optional description of the user.
 			MAILDIR is the name of the folder inside <b>/var/spool/mail/virtual</b>.
-			It must end in a /, otherwise it wont be used as a unix maildir format.
-			CRYPT is the encrypted text password to use.
+			It must end in a /, otherwise it won't be used as a unix maildir format.
+			CRYPT is the encrypted password.
 		</p>
 		<p>
-			The alises are the interesting part.
-			Lets start from a top down view to see how emails get delivered:
+			The aliases are the interesting part.
+			Let's start from a top down view to see how emails get delivered:
 		</p>
 		<p>
 			Say an email arrives addressed to <i>"john@whopper.nu"</i>.
 		<ul>
 			<li><p>
-				Postfix looks up domains and say <i>whopper.nu</i> is an domain it listens to.
+				Postfix looks up domains and say <i>whopper.nu</i> is a domain it listens to.
 			</p></li>
 			<li><p>
 				Postfix then looks up aliases and searches for a row where the mail field matches <i>"john@whopper.nu"</i>.
@@ -2920,11 +2920,11 @@ INSERT INTO aliases (mail,destination) VALUES
 
 
 		<p>
-				Lets try <i>"julian.whippit@lala.com"</i>.
+				Let's try <i>"julian.whippit@lala.com"</i>.
 		</p>
 		<ul>
 			<li><p>
-				Postfix looks up domains and it is an domain it listens to.
+				Postfix looks up domains and it is a domain it listens to.
 			</p></li>
 			<li><p>
 				First lookup does not find this user,
@@ -2942,7 +2942,7 @@ INSERT INTO aliases (mail,destination) VALUES
 				Any mail arriving for <i>"karl@blobber.org"</i> or <i>"karl@lala.com"</i>,
 				gets forward to an external address of <i>"karl.vovianda@gmail.com"</i>.
 				So forwarding is simple. I tend to use a subdomain for all my friends
-				addresses as easily I forget what their real addresses
+				addresses as I easily forget what their real addresses
 				are, and I use different email clients all the time.
 			</p>
 
@@ -3068,15 +3068,15 @@ order by d.domain,a.mail</code>
 		<li>
 			<h5>Missed a step</h5>
 			<p>
-				If you mistakenly or intentially skipped past sections,
+				If you mistakenly or intentionally skipped past sections,
 				you may have missed an important step in your configuration,
-				which my guide pressumes you have followed.
+				which my guide presumes you have followed.
 			</p>
 		</li>
 		<li>
 			<h5>Typo</h5>
 			<p>
-				99% of all problems is spelling errors or typos you entered
+				99% of all problems are spelling errors or typos you entered
 				while following this guide. Sorry, but it just happens.
 				Often it can be trivial, such as a <i>space</i> at the end
 				of the configuration line which was not expected etc.
@@ -3095,21 +3095,21 @@ order by d.domain,a.mail</code>
 		<li>
 			<h5>Different application or configurations</h5>
 			<p>
-				It is obviously entirely up to you how you set up your system.
+				It is obviously entirely up to you how you setup your system.
 				But the more you deviate from this guide,
 				the more likely incompatibilties or confusion will arrise.
 			</p>
 		</li>
 		<li>
-			<h5>Distrobution/version differences</h5>
+			<h5>Distribution/version differences</h5>
 			<p>
-				If you run a different version or even distrobution to this guide,
+				If you run a different version or even distribution to this guide,
 				then some things will be different.
 				Small issues, such as default values and significant things
 				such as path differences etc.
-				Some sections in this guide are not always thouroughly
+				Some sections in this guide are not always thoroughly
 				tested with every new release of Ubuntu,
-				but these differences gets <a href="#contact">pointed out by people for me</a>.
+				but these differences get <a href="#contact">pointed out by people for me</a>.
 			</p>
 		</li>
 		<li>
@@ -3139,17 +3139,17 @@ order by d.domain,a.mail</code>
 
 	<h5>Test early and frequently</h5>
 	<p>
-		It is very helpfull to test early in this set up,
+		It is very helpful to test early in this setup,
 		to establish if the first sections are working as expected.
 	</p>
 	<p>
 		So when you only have your very basic postfix and mysql up: Test it!<br/>
 		That way you know that bit worked and can rule it out of any future problems.<br/>
-		Don't wait till you complicated and mudded the water after amavis, courier etc is added.
+		Don't wait till you complicated and mudded the water after amavis, courier etc are added.
 	</p>
 	<p>
 		By constantly testing if you can send and receive you can tick off and black box
-		each section as working, and immidietly spot issues.
+		each section as working, and immediately spot issues.
 	</p>
 
 
@@ -3159,8 +3159,8 @@ order by d.domain,a.mail</code>
 		So by using the steps of testing  early above, you can see which step caused the problem.
 	</p>
 	<p>
-		Also if you can't log into your webmail it is often nothing to do with the webmail section
-		that is causing the problem. Often postfix itself is broken etc.
+		Also if you can't log into your webmail, the cause of the problem often has
+		nothing to do with the webmail section. Often postfix itself is broken etc.
 	</p>
 
 
@@ -3172,8 +3172,8 @@ order by d.domain,a.mail</code>
 		This would then quickly isolate the problem when e.g. such as above issues of reading emails via the webmail.
 		This would be in order:
 		<ol>
-			<li><p>Access: Can I get(ssh) to the box, and is there a firewall issue?</p></li>
-			<li><p>Database: Is the database up, do my application reach it?</p></li>
+			<li><p>Access: Can I get (ssh) to the box, and is there a firewall issue?</p></li>
+			<li><p>Database: Is the database up, does my application reach it?</p></li>
 			<li><p>Postfix: Can I send email by command line, do I receive emails via telnet?</p></li>
 			<li><p>Content checks: Do they cause a problem?</p></li>
 			<li><p>Courier: Can I read emails?</p></li>
@@ -3185,7 +3185,7 @@ order by d.domain,a.mail</code>
 	<p>
 		Assisting in isolating the problem,
 		you often have to disable options and applications.
-		Such as turn of postgrey or content checks to make sure emails to get delivered.
+		Such as turn of postgrey or content checks to make sure emails get delivered.
 	</p>
 
 	<p><a href="edition5.html#test">Previous editions</a> do have some more detail on how to achieve this</p>
@@ -3223,7 +3223,7 @@ order by d.domain,a.mail</code>
 	<p><i><a href="edition5.html#test">previous edition 1</a></i></p>
 	<p><i><a href="edition5.html#test2">previous edition 2</a></i></p>
 	<p>
-		The previous editions has detail on switching services off until time to test them.
+		The previous editions have details on switching services off until time to test them.
 		<br/>
 		It also details locking down your server from spammers until finished testing.
 	</p>
@@ -3258,7 +3258,7 @@ order by d.domain,a.mail</code>
 
 	<h5>Courier</h5>
 	<p>
-		As mentioned in the setup , switching on debugging for Courier is easy:
+		As mentioned in the setup, switching on debugging for Courier is easy:
 		<code>sudo vi /etc/courier/authdaemonrc</code>
 		<code class="document">DEBUG_LOGIN=2</code>
 	</p>
@@ -3298,10 +3298,10 @@ order by d.domain,a.mail</code>
 	<a name="test-postfix-receive"></a>
 	<h4>Can postfix receive?</h4>
 	<p>
-		Lets assume:
+		Let's assume:
 			<ul>
-				<li><p>You have followed my guide up to <a href="#config-simple">basic configuration</a> at least</p></li>
-				<li><p>You have entered <a href="#data">data</a> into the database</p></li>
+				<li><p>You have followed my guide up to <a href="#config-simple">basic configuration</a> at least.</p></li>
+				<li><p>You have entered <a href="#data">data</a> into the database.</p></li>
 				<li><p>The services MySQL and Postfix are running.</li>
 				<li><p>If testing a fuller stack, then amavis, postgrey, clamav-daemon, spamassassin etc must also be running.</li>
 			</ul>
@@ -3310,7 +3310,7 @@ order by d.domain,a.mail</code>
 		Try this locally on the server first, then try from another machine once it is working locally.
 	</p>
 	<p>
-		Lets try and send a message to <i>xandros@example.org</i>
+		Let's try and send a message to <i>xandros@example.org</i>
 		(replace with your own user in this setup, or use postmaster@localhost)
 		from <i>you@example.com</i>
 		(again replace with a real email address you use that is not associated with this server.)
@@ -3332,7 +3332,7 @@ RCPT TO: &lt;<i>xandros@example.org</i>&gt;
 <span class="comment"># then enter the keyword <i>data</i></span>
 data
 <span class="reply">&gt; 354 End data with &lt;CR&gt;&lt;LF&gt;.&lt;CR&gt;&lt;LF&gt;&lt;/LF&gt;&lt;/CR&gt;&lt;/LF&gt;&lt;/CR&gt;</span>
-<span class="comment"># enter message bodyand end with a line with only a full stop.</span>
+<span class="comment"># enter message body and end with a line with only a full stop.</span>
 blah blah blah
 more blah
 .
@@ -3345,7 +3345,7 @@ quit
 
 	<p>
 		If while you were doing this you were tailing the <i>/var/log/mail.log</i>
-		you would see some activities and if any errors occured.
+		you would see some activities and if any errors occurred.
 		(You should probably get some complaints about missing headers as we skipped most...)
 	</p>
 	<p>
@@ -3375,7 +3375,7 @@ quit
 	</ul>
 	<p>
 		Basically you just tested that above,
-		but we need double check if it can send out to other servers.
+		but we need to double check if it can send out to other servers.
 		Again we will first test locally, which should work,
 		then remotely which introduces many possible problems.
 		<code>telnet localhost 25
@@ -3396,7 +3396,7 @@ RCPT TO: &lt;<i>you@example.com</i>&gt;
 <span class="comment"># then enter the keyword <i>data</i></span>
 data
 <span class="reply">&gt; 354 End data with &lt;CR&gt;&lt;LF&gt;.&lt;CR&gt;&lt;LF&gt;&lt;/LF&gt;&lt;/CR&gt;&lt;/LF&gt;&lt;/CR&gt;</span>
-<span class="comment"># enter message bodyand end with a line with only a full stop.</span>
+<span class="comment"># enter message body and end with a line with only a full stop.</span>
 blah blah blah
 more blah
 .
@@ -3407,14 +3407,14 @@ quit
 	</p>
 	<p>
 		We have to assume receiving works above so no need to tail mysql's logs.
-		However if any rejection errors occured in the mail.log then you have an error.
+		However if any rejection errors occurred in the mail.log then you have an error.
 	</p>
 	<p>
-		However if no errors occured and you see in the log something like this:
+		However if no errors occurred and you see in the log something like this:
 		<code>Dec 17 10:25:45 <i>servername</i> postfix/smtp[12345]: 12345678: to=<i>&lt;you@example.com&gt;</i>, relay=127.0.0.1[127.0.0.1]:10024,
 delay=15, delays=15/0.01/0.02/0.11, dsn=2.0.0, status=sent (250 2.0.0 Ok, id=12345-09, from MTA([127.0.0.1]:10025):
 250 2.0.0 Ok: queued as 1234567)</code>
-		Then the sending emails work!
+		Then sending emails works!
 	</p>
 
 	<h6><a href="#top">Return to top</a>.</h6>
@@ -3433,9 +3433,9 @@ delay=15, delays=15/0.01/0.02/0.11, dsn=2.0.0, status=sent (250 2.0.0 Ok, id=123
 	<a name="test-courier"></a>
 	<h4>Can courier read emails</h4>
 	<ul>
-		<li><p>You need to make sure you can first receive emails as above</p></li>
-		<li><p>You need to make sure you can send emails as above</p></li>
-		<li><p>You need to make sure you have received an email and the folder /var/mail/virtual/<i>xandros</i> exists</p></li>
+		<li><p>You need to make sure you can first receive emails as above.</p></li>
+		<li><p>You need to make sure you can send emails as above.</p></li>
+		<li><p>You need to make sure you have received an email and the folder /var/mail/virtual/<i>xandros</i> exists.</p></li>
 		<li><p>The services MySQL, courier-authdaemon and courier-imap are running.</li>
 	</ul>
 	<p>
@@ -3454,9 +3454,9 @@ Escape character is '^]'.
 	<a name="test-amavis"></a>
 	<h4>Can amavis check and pass emails along?</h4>
 	<ul>
-		<li><p>You need to make sure you can first receive emails as above</p></li>
-		<li><p>You need to make sure you can send emails as above</p></li>
-		<li><p>You need to make sure you have received an email and the folder /var/mail/virtual/<i>xandros</i> exists</p></li>
+		<li><p>You need to make sure you can first receive emails as above.</p></li>
+		<li><p>You need to make sure you can send emails as above.</p></li>
+		<li><p>You need to make sure you have received an email and the folder /var/mail/virtual/<i>xandros</i> exists.</p></li>
 	</ul>
 	<p>
 		You can check if the service is responding:
@@ -3483,7 +3483,7 @@ Escape character is '^]'.
 <div class="section">
 
 	<p>
-		Brief hints if you receive a ready setup machine (or EC2 AMI),
+		Brief hints if you receive a ready set up machine (or EC2 AMI),
 		and what then to check and to customize it to your setup.
 	</p>
 	<ul>
@@ -3538,12 +3538,12 @@ sudo /etc/init.d/clamav stop</code>
 	</p>
 	<h5>SSH Access</h5>
 	<p>
-		Next we check whom got SSH access.
-		If there was any users defined,
+		Next we check who got SSH access.
+		If there were any users defined,
 		check their home folders for ssh keys.
 		<code>cat /home/<i>username</i>/.ssh/auth*</code>
 		Remove any you do not expect to be there.
-		Next check if and which specific users has been defined
+		Next check if and which specific users have been defined
 		for SSH access in
 		<code>vi /etc/ssh/sshd</code>
 		Usually this is fine.
@@ -3565,7 +3565,7 @@ sudo /etc/init.d/clamav stop</code>
 		Enter new root password specified above, then:
 		<code>update mysql.user set password=password('<i>apassword</i>') where user='mail';
 flush privileges;</code>
-		You may	need to revisit the top of <a href="#conf-simple-database">MySQL section</a>
+		You may	need to revisit the top of the <a href="#conf-simple-database">MySQL section</a>
 		to re-grant the mail use rights on the database.
 	</p>
 	<p>
@@ -3622,13 +3622,13 @@ flush privileges;</code>
 	<p>
 		You could go along with the generated certificates
 		(if they are there, default for Ubuntu).
-		Or if you could create new ones with the correct machine name in them.
-		Especially if this a mail server used by many, and authenticiy is important.
+		Or you could create new ones with the correct machine name in them.
+		Especially if this is a mail server used by many, and authenticity is important.
 		Follow the <a href="#config-secure-tsl">TLS certificate instructions</a> for
 		Postfix and Courier.
 	</p>
 
-	<h4>Start and test services.</h4>
+	<h4>Start and test services</h4>
 	<p>
 		Next you need to start your mail services and test them.
 		<code>sudo /etc/init.d/mysql start
@@ -3641,7 +3641,7 @@ sudo /etc/init.d/courier-imap start
 sudo /etc/init.d/courier-authdaemon start</code>
 	</p>
 	<p>
-		So test tjenestene via <a href="#test">testing section</a>.
+		So test the services via <a href="#test">testing section</a>.
 	</p>
 
 	<h4>Insert data<h4>
@@ -3649,8 +3649,8 @@ sudo /etc/init.d/courier-authdaemon start</code>
 		Insert your mail domains, aliases and users using the  <a href="#data">data section</a>.
 	</p>
 	<p>
-		Some times there are test data already in the database. Remove them.
-		E.g.;
+		Sometimes there are test data already in the database. Remove them.
+		E.g.:
 		<code>mysql -u mail -p<i>apassword</i> maildb</code>
 		<code>delete from domains where domain = 'bar.com';
 delete from aliases where mail = 'foo@bar.com';</code>
@@ -3735,16 +3735,16 @@ delete from aliases where mail = 'foo@bar.com';</code>
 	<h3>Remote MX mail backup</h3>
 
 		<p>
-		With MX backup loosing emails are unlikely.
+		With MX backup losing emails is unlikely.
 		</p>
 		<p>
 		Normally if someone sends an email destined for you,
 		their server will try and connect to your server.
 		If it can't reach your server for whatever reason
-		( it is down, dns issues, there is network problems, or just too busy ),
+		(it is down, dns issues, there are network problems, or just too busy),
 		the other server will back off and try again in a bit.
 		How many and for how long it will try again is determined
-		by the sending server. Some of them are not very patience,
+		by the sending server. Some of them are not very patient,
 		and it will report undelivered after only a few attempts.
 		So you would have lost that email.
 		</p>
@@ -3760,10 +3760,10 @@ delete from aliases where mail = 'foo@bar.com';</code>
 		</p>
 		<p>
 			What is the difference?
-			Simple, you (or whoever controls the backup mx )
+			Simple, you (or whoever controls the backup mx)
 			is in control how long and often to try connecting
 			to your machine.
-			So if you have a reasonable values and your server
+			So if you have reasonable values and your server
 			is not down for weeks, no mail is lost.
 		</p>
 		<p>
@@ -3780,9 +3780,9 @@ delete from aliases where mail = 'foo@bar.com';</code>
 
 	<p>
 		Now presuming the other backup mx is a postfix
-		server identical to this, or you are backuing up someone else's
+		server identical to this, or you are backing up someone else's
 		server;
-		Go into mysql and create this tables:
+		Go into mysql and create this table:
 	</p>
 
 	<code>CREATE TABLE `backups` (
@@ -3807,15 +3807,15 @@ transport_maps = mysql:/etc/postfix/mysql_transport.cf</code>
 		as you may use small cron jobs to modify this ip address,
 		if you don't have a permanent static address.
 		It should contain your IP addres, hence if you do not
-		have a very static IP address, then you need some way of
-		automatic edit the postfix main.cf file.
+		have a very static IP address, then you need some way to
+		automatically edit the postfix main.cf file.
 	</p>
 
 	<code class="document">proxy_interfaces = <i>1.2.3.4</i></code>
 
 
 		<p>
-			If someone comes with a better way,
+			If someone comes up with a better way,
 			<a href="#contact">then let me know</a>.
 		</p>
 		<p>
@@ -3848,13 +3848,13 @@ additional_conditions = and enabled = 1</code>
 		You noticed I added a transport lookup.
 		This is a field in both the domain and the backup tables.
 		In domains it is used to determine how to deliver
-		the email, ie either virtual (correct) or local
+		the email, i.e. either virtual (correct) or local
 		(not used in this howto).
 		When backing up servers, your also need to specify
 		in the transport field how to connect to the correct servers.
 		</p>
 		<p>
-		Say you are backup for a friends server, mail.friend.com,
+		Say you are a backup for a friends server, mail.friend.com,
 		for the domains of friend1.com and friend2.com.
 			So you should insert this into your backup table.
 		</p>
@@ -3874,8 +3874,8 @@ VALUES ('<i>friend1.com</i>' , ':[<i>mail.friend.com</i>]' ),
 			Further tweaking of the queue values,
 			review these and modify as appropriate.
 			Shorter warning times are good for the sender,
-			so that they realise the email has not arrived yet,
-			but may also be annoying. Tradeoffs..
+			so that they realize the email has not arrived yet,
+			but may also be annoying. Trade-offs.
 			Look in the first <a href="#config_mta">main.cf configurations</a>
 			for ways to do so.
 		</p>
@@ -3889,10 +3889,10 @@ VALUES ('<i>friend1.com</i>' , ':[<i>mail.friend.com</i>]' ),
 	<p>
 		They simply lookup a domain's MX servers and connect directly to one of the lower priority servers
 		whom may be just a backup mx. This server if configured as above will not check for valid addresses aliases
-		but will accept and queue all emails for the domain's it is configured as a backup mx for.
+		but will accept and queue all emails for the domains it is configured as a backup mx for.
 		These will then be delivered by the server later to the primary MX server,
-		whom will then maybe reject them as the aliases are not valid. However the sender addresses
-		are often invalid and a long trail of reject messages to and forth around the net follows...
+		who will then maybe reject them as the aliases are not valid. However the sender addresses
+		are often invalid and a long trail of reject messages to and fro around the net follows...
 	</p>
 	<p>
 		To avoid this you can enable relay recipient lookup in Postfix.
@@ -3942,7 +3942,7 @@ additional_conditions = and enabled = 1</code>
 	<a name="ext_back"></a>
 	<h3>Local file backup</h3>
 	<p>
-		Here is rough backup script to backup your configurations
+		Here is a rough backup script to backup your configurations
 		and mail folders.
 		You may want to backup the folders separately
 		as they can quickly grow to GBs.
@@ -3962,7 +3962,7 @@ tar cf mail.xxxxx.tar  mail-*.xxxxx.tgz </code>
 
 	<p>
 		You may combine a full backup
-		with a intermediate update of what has changed recently only.
+		with an intermediate update of what has changed recently only.
 	</p>
 
 	<code>tar --newer-mtime "2005-01-01"</code>
@@ -3973,7 +3973,7 @@ tar cf mail.xxxxx.tar  mail-*.xxxxx.tgz </code>
    <a name="ext_email_auth"></a>
    <h3>Email Authentication (server-to-server)</h3>
    	<p>
-         To verify the sender is who they send they are (too avoid spam and phising) there are a few choices:
+         To verify that senders are who they say they are (to avoid spam and phising) there are a few choices:
    	</p>
          <ul>
             <li><p>SPF</p></li>
@@ -3993,7 +3993,7 @@ tar cf mail.xxxxx.tar  mail-*.xxxxx.tgz </code>
    	</p>
 		<h4>SPF DNS configuration</h4>
 		<p>
-			The OpenSPF site has some nice <a href="http://www.openspf.org/Tools">SPF generation tools</a> to setup your SPF configuration.
+			The OpenSPF site has some nice <a href="http://www.openspf.org/Tools">SPF generation tools</a> to set up your SPF configuration.
 		</p>
 		<p>
 			But the way I have my setup, is generally one domain with detailed SPF in its DNS, then all other domains just with an SPF alias to it.
@@ -4068,7 +4068,7 @@ Mail_From_reject = False</code>
       <p>
          And then add the policy check to your <em>smtpd_recipient_restrictions</em>.
          If you have <em>permit_mynetworks</em> before it, it will correctly skip checking SPF for local mail.
-         Make sure this lines are after the <em>reject_unauth_destination</em>.
+         Make sure these lines are after the <em>reject_unauth_destination</em>.
       </p>
       <code class="document">smtpd_recipient_restrictions = 
 <span class="comment">...</span>
@@ -4104,16 +4104,16 @@ permit
 			Trixie's email address is actually an alias and forwards the email to her private webmail account on <i>hotmailnot.com</i>.
 		</p>
 		<p>
-			Now if your domain, <i>hoopa.com</i>, have a strict SPF set up, which only allows emails to be sent by its mail server.
-			And you/the mail admin has added <i>-all</i> to the SPF, which tells other server to reject emails not from your server.
-			This you think makes sense, spammers can not use your domain for spoof emails.
+			Now if your domain, <i>hoopa.com</i>, has a strict SPF setup, it only allows emails to be sent by its mail server.
+			And you/the mail admin has added <i>-all</i> to the SPF, it tells other servers to reject emails not from your server.
+			This you think makes sense, spammers cannot use your domain for spoof emails.
 		</p>
 		<p>
-			So what happens: bellbell.org receives the email from lulu, and possible checks the SPF, which is OK, and forwards it on to hotmailnot.com.<br/>
+			So what happens: bellbell.org receives the email from lulu, and possibly checks the SPF, which is OK, and forwards it on to hotmailnot.com.<br/>
 			However if hotmailnot.com also checks SPF, it will receive the email from bellbell.org, check the SPF to see bellbell.org's mail server is allowed to send emails on behalf hoopa.com. SPF will say No!, and with the -all, hotmailnot.com email server will reject the email!
 		</p>
 		<p>
-			2nd scenario if lulu email trixie directly at hotmailnot.com,
+			2nd scenario if lulu emails trixie directly at hotmailnot.com,
 			but hotmailnot.com main mail server was down, and email was sent to the backup mx server.
 			When the main server came online again, and the backup spooled the email back to it,
 			the SPF would again fail as the hoopa.com's SPF would not mention hotmailnot.com backup mx as an allowed mail server.
@@ -4121,8 +4121,8 @@ permit
 		</p>
 		<p>
 			<b>Prevention</b>: <br/>
-			Of course you can not list all possible forwarding / backup mx email server that your domain's users might at some point email!<br/>
-			I simple just use the ~all option. Which simple say it is not the expected server, but probably ok. <br/>
+			Of course you can not list all possible forwarding / backup mx email servers that your domain's users might at some point email!<br/>
+			I simple just use the ~all option. Which simple says it is not the expected server, but probably ok. <br/>
 			And if this is added to a scoring by the receiver, then the accumulated spam score might be enough to reject dodgy emails.
 		</p>
 
@@ -4167,8 +4167,8 @@ recipient_canonical_classes = envelope_recipient,header_recipient</code>
    <a name="ext_dkim"></a>
       <h4>DKIM</h4>
       <p>
-         <a href="http://www.dkim.org/">DKIM</a> offer public key that checks if email sender is allowed so send on behalf of that domain.
-         It is quite rubust and well supported.
+         <a href="http://www.dkim.org/">DKIM</a> offers a public key that checks if the email sender is allowed so send on behalf of that domain.
+         It is quite robust and well supported.
       </p>
       <code>sudo apt-get install opendkim opendkim-tools</code>
 
@@ -4226,7 +4226,7 @@ non_smtpd_milters = unix:/var/run/opendkim/opendkim.sock
       
       <code>sudo vi /etc/postfix/master.cf</code>
       
-      At the bottom of <em>master.cf</em> lets add a <em>no_milters</em>
+      At the bottom of <em>master.cf</em> let's add a <em>no_milters</em>
       config to the amavis integration:
       <code class="document">
 127.0.0.1:10025 inet    n       -       -       -       -       smtpd
@@ -4258,8 +4258,8 @@ sudo mv default.* /etc/opendkim/keys/<i>example.org</i>/</code>
       <h5>Configure Domains</h5>
 
       <p>
-         First lets add IPs that we trust, ie we will sign the emails from these IPs. 
-         Lets assum your server's public ip is <em>1.2.3.4</em>. 
+         First let's add IPs that we trust, i.e. we will sign the emails from these IPs. 
+         Let's assume your server's public ip is <em>1.2.3.4</em>. 
          If you have any other servers that use this server to send emails on to the internet,
          webmail etc,
          then list those ips and hostnames as well.
@@ -4397,7 +4397,7 @@ set from="<i>You</i> &lt;<i>you</i>@<i>example.com</i>&gt;"
 			You can implement further lists inside Postfix or SpamAssassin.
 			Amavisd-new already has a few well known white/black listed items
 			in its config files.
-			SpamAssissin also as a feture to automaticly learn white lists.
+			SpamAssissin also has a feature to automatically learn white lists.
 		</p>
 
 	<h6><a href="#top">Return to top</a>.</h6>
@@ -4411,7 +4411,7 @@ set from="<i>You</i> &lt;<i>you</i>@<i>example.com</i>&gt;"
 		</p>
 		<p>
 			This is not implemented on the postfix server side,
-			as this totally a client side option.
+			as this is totally a client side option.
 		</p>
 		<p>
 			However SquirrelMail has a GnuPG option.
@@ -4465,7 +4465,7 @@ gpg --gen-key</code>
 		if people send email to the old address
 		is quite useful.
 		To implement this in postfix,
-		frst create a lookup table in the database.
+		first create a lookup table in the database.
 	</p>
 	<code class="document">CREATE TABLE `relocated` (
 `pkid` smallint(6) NOT NULL auto_increment,
@@ -4480,7 +4480,7 @@ UNIQUE KEY `oldadr` (`oldadr`)
 
 	<code class="document">relocated_maps = mysql:/etc/postfix/mysql_relocated.cf</code>
 
-	<p>The create this file /etc/postfix/mysql_relocated.cf</p>
+	<p>Then create this file /etc/postfix/mysql_relocated.cf</p>
 
 	<code class="document">user=mail
 password=<i>apassword</i>
@@ -4526,12 +4526,12 @@ hosts=127.0.0.1</code>
 		If SASL didn't work, or you are using clients which
 		dont support it, the Pop-Before-SMTP is an easy way
 		around that issue, so that people externally can
-		still securly send mail via your server.
+		still securely send mail via your server.
 	</p>
 	<p>
 		Refer to my
 		<a href="edition2.html#send">2nd edition</a>
-		on Pop-before-SMTP	setup.
+		on Pop-before-SMTP setup.
 	</p>
 	<h6><a href="#top">Return to top</a>.</h6>
 
@@ -4540,16 +4540,16 @@ hosts=127.0.0.1</code>
 	<h3>Admin software</h3>
 
 	<p>
-		Trying out a few admin software might make you life
+		Trying out some admin software might make your life
 		easier, if command line or phpMyAdmin gets to crude.
-		<a href="http://www.google.com/search?q=postfix+admin">Quick search
+		A <a href="http://www.google.com/search?q=postfix+admin">quick search
 		for postfix admin</a> will find many options.
 	</p>
    <h4>Sorting Office</h4>
 	<p>
 		I have made the application <a href="http://github.com/flurdy/sortingoffice">Sorting Office</a>,
       availalbe at <a href="http://github.com/flurdy/sortingoffice">github.com/flurdy/sortingoffice</a>.
-		It is for managing data in the database(s), ie domains, users, aliases etc
+		It is for managing data in the database(s), i.e. domains, users, aliases etc
 		and not for configuration.
    </p>
    <p>
@@ -4567,7 +4567,7 @@ hosts=127.0.0.1</code>
 	<h3>Auto Reply</h3>
 	<h6 class="red">todo</h6>
 		<p>
-			Postfix have now features to auto reply to an email,
+			Postfix now has features to auto reply to an email,
 			while still delivering it to its alias.
 		</p>
 		<p>
@@ -4586,9 +4586,8 @@ hosts=127.0.0.1</code>
 		or stop indivdual addresses.
 		</p>
 		<p>
-			By implementing a lookup
-			and adding this restriction to smtpd_recipient_restrictions
-			accomplises this.
+			Implementing a lookup	and adding this restriction to
+			smtpd_recipient_restrictions accomplishes this.
 		</p>
 	<code class="document">check_recipient_access mysql:/etc/postfix/mysql_block_recip.cf,</code>
 
@@ -4598,12 +4597,11 @@ hosts=127.0.0.1</code>
 	check_relay_domains</code>
 
 	<p>
-		Beware of the order is important here, if any options says ok before check_recipient_access it will ignore it.
+		Beware, the order is important here, if any option says ok before check_recipient_access it will ignore it.
 		</p>
 		<p>
 			Next create mysql_block_recip.cf to lookup addresses.
-			Either create a another table,
-			or add a blocked field to aliases table.
+			Either create another table, or add a blocked field to aliases table.
 		</p>
 
 	<h6><a href="#top">Return to top</a>.</h6>
@@ -4614,7 +4612,7 @@ hosts=127.0.0.1</code>
 	<h6 class="red">todo</h6>
 	<p>
 		For some users with restrictions on bandwidth,
-		you may wish to control how much mail is sendt out.
+		you may wish to control how much mail is sent out.
 		Postfix has long refused to implement these features,
 		out of ideolocial beliefs that mail servers should
 		not be restricted.
@@ -4650,7 +4648,7 @@ hosts=127.0.0.1</code>
 	<p>
 			If you want a simple mailling list,
 			it can be implemented
-			by simply seperating aliases in the
+			by simply separating aliases in the
 			destination field in the aliases table with a comma.
 	</p>
 
@@ -4681,9 +4679,9 @@ hosts=127.0.0.1</code>
 	<h4>How</h4>
 	<h5>Options</h5>
 		<p>
-			The easiest and simples solution is not to have a domain MXed to your server,
+			The easiest and simplest solution is not to have a domain MXed to your server,
 			and simply alias email to those domains.
-			eg All email to joeblogs.co.uk hosted on your server
+			E.g. all emails to joeblogs.co.uk hosted on your server
 			are forwarded to joeblogs.com hosted with google.
 		</p>
 		<p>
@@ -4695,21 +4693,21 @@ hosts=127.0.0.1</code>
 		</p>
 		<p>
 			However the one I use and the option where you are most in control
-			is to keep you server as the only MX server in the DNS.
+			is to keep your server as the only MX server in the DNS.
 			And only forward certain aliases onto Google after all your servers checks.
-			Other aliases and user can just use your mail server if you prefer.
+			Other aliases and users can just use your mail server if you prefer.
 			I will explain how to do this in the next steps.
 		</p>
 	<h5>DNS</h5>
 	<p>
 		You only put your mail server as the mx for the domain in question.
 		Google will complain about this, as it will not be able to verify that
-		email is setup correctly. Ignore this as it will still accept emails.
+		email is set up correctly. Ignore this as it will still accept emails.
 	</p>
 	<h5>MySQL tables</h5>
 	<p>
-		You setup you aliases as normal.
-		However you domain table needs tweaking.
+		You set up you aliases as normal.
+		However your domain table needs tweaking.
 		This is because otherwise your server
 		will just forward the email to itself.
 		You can actually specify aliases in the domain table.
@@ -4744,7 +4742,7 @@ hosts=127.0.0.1
 additional_conditions = and enabled = 1</code>
 	</p>
 	<p>
-		Assuming there are no <i>bloggs.com</i> data in any tables (domain,alias,users,relays,backups):
+		Assuming there are no <i>bloggs.com</i> data in any tables (domain, alias, users, relays, backups):
 
 		<code>insert into backups (domain,transport) values
 		('<i>joe@bloggs.com</i>','smtp:[aspmx.l.google.com]:587'),
@@ -4759,7 +4757,7 @@ insert into users (id,name,maildir,crypt) values
 		The domains insert is the interesting one.
 		The transport map lookup checks recursively for an alias match and will first look
 		for <i>user@domain</i> before it looks at the general <i>bloggs.com</i> for which transport to use.
-		The square brackets around <i>aspmx.l.google.com</i> indicates that this server
+		The square brackets around <i>aspmx.l.google.com</i> indicate that this server
 		will not lookup for mx settings for this domains DNS, but instead connect directly.
 		(This can avoid never ending recursive lookups/relays)
 	</p>
@@ -4774,7 +4772,7 @@ insert into users (id,name,maildir,crypt) values
 	<p>
 		If you have set your server up to <a href="#conf-secure-crypt">prefer TLS</a>
 		then you should add Google's signing authority to your server's root certificate list.
-		Google used to use Thawte but now use Equifax.
+		Google used to use Thawte but now uses Equifax.
 		On the latest Ubuntu releases this is no longer needed as it is already included.
 	</p>
 	<p>
@@ -4828,7 +4826,7 @@ sudo service postfix restart;</code>
 	</p>
 	<p>
 		<b>Google internally</b><br />
-		Be aware Google think they host you domain.
+		Be aware Google thinks they host your domain.
 		So if others inside google, or using google hosted apps or GMail,
 		if they email you, the email may not go via your email server,
 		but directly to the Google Apps for your domain.
@@ -4847,7 +4845,7 @@ sudo service postfix restart;</code>
 	<a name="ext_maildrop"></a>
 	<h3>Maildrop, spam folder and vacation messaging</h3>
 	<p>
-		Villu have documented swapping in Maildrop for virtual transport
+		Villu has documented swapping in Maildrop for virtual transport
 		and automatically delivering spam to a spam folder.
 		(And links to a post about vacation messaging)
 	</p>
@@ -4873,11 +4871,11 @@ sudo service postfix restart;</code>
 		<code>sudo a2ensite squirrelmail</code>
 	</p>
 	<p>
-		You may accept the default apache configuration where squirrelmail is folder in all sites. But I prefer virtual hosting. But you dont need to do these next steps.
+		You may accept the default apache configuration where squirrelmail is a folder in all sites. But I prefer virtual hosting. But you don't need to do these next steps.
 		<code>sudo vi /etc/apache2/sites-available/squirrelmail</code>
 		Comment out the alias.
 		<code class="document"><span class="comment"># alias /squirrelmail /usr/share/squirrelmail</span></code>
-		Uncomment the virtual settings.,
+		Uncomment the virtual settings,
 		and insert your servers name.
 		<code class="document"><span class="comment"># users will prefer a simple URL like http://webmail.example.com</span>
 <VirtualHost *>
@@ -4895,10 +4893,10 @@ sudo service postfix restart;</code>
 		<code>sudo /etc/init.d/apache2 reload</code>
 	</p>
 	<p>
-		You can now go to<b><i>yourdomain.com/squirrelmail/</i></b>
+		You can now go to <b><i>yourdomain.com/squirrelmail/</i></b>
 		or <b><i>mail.yourdomain.com</i></b> if you chose virtual host.
 		This should show a squirrel mail page.
-		Log in wont work yet though.
+		Log in won't work yet though.
 	</p>
 
 	<h5>
@@ -4920,7 +4918,7 @@ sudo service postfix restart;</code>
 	</p>
 	<p>
 		Now they say using TLS over localhost is a waste of time.
-		But I do anyway.
+		But I do it anyway.
 		Type <b><i>7</i></b> to edit secure IMAP.
 		Type <b><i>Y</i></b> to enable it.
 	</p>
@@ -4942,7 +4940,7 @@ sudo service postfix restart;</code>
 		Log in will now work.
 		<i>(Except you may not have defined users, check <a href="#data">data</a>
 		section. And they may not have received an email which also means
-		you can not view any IMAP info.)</i>
+		you cannot view any IMAP info.)</i>
 	</p>
 
 	<p>
@@ -4957,11 +4955,11 @@ sudo service postfix restart;</code>
 	<a name="ext_brute"></a>
 	<h3>Brute force</h3>
 	<p>
-		Preventing <a href="http://en.wikipedia.org/wiki/Brute-force_attack">Brute Force</a> attack on your server.
+		Preventing <a href="http://en.wikipedia.org/wiki/Brute-force_attack">Brute Force</a> attacks on your server.
 	</p>
 	<p>
 		First line of defence is the firewall.
-		If they cant get to your server then they cant hack in.
+		If they can't get to your server then they can't hack in.
 		However to be a useful internet based server you have to expose
 		some services, e.g. SMTP.
 	</p>
@@ -5070,7 +5068,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 		If you have any suggestions to other ways of extending
 		a postfix server, then fire off a mail to me via
 		the <a href="#contact">contact form</a> further down.<br/>
-		(Or rather, Id prefer that you write down the extension, and let me know the link! :))
+		(Or rather, I'd prefer that you write down the extension, and let me know the link! :))
 	</p>
 </div>
 <h6><a href="#top">Return to top</a>.</h6>
@@ -5097,7 +5095,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 	</div>
 	<ul>
 		<li><p><a href="#ec2">Impressions</a></p></li>
-		<li><p><a href="#ec2_tips">ec2 introduction, tips and hwotos</a></p></li>
+		<li><p><a href="#ec2_tips">ec2 introduction, tips and howtos</a></p></li>
 		<li><p><a href="#ec2_use">Using EC2 with this howto</a></p></li>
 		<li><p><a href="#ec2_ami">Amazon EC2 Images: AMIs</a></p></li>
 		<li><p><a href="#ec2_links">EC2 Links</a></p></li>
@@ -5107,16 +5105,16 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 
 	<p>
 		Easy to use.
-		Anyone can use, not just big companies.
+		Anyone can use it, not just big companies.
 		Very useful.
 		Tools are command line but simple.
 		Firefox extensions work well.
 		Recommended.
 	</p>
 	<p>
-		I find it very usefull.
-		Basically it is a colo hosting environment.
-		Some may use it as for Saas, ie single scalable application in the cloud,
+		I find it very useful.
+		Basically it is a colocation hosting environment.
+		Some may use it for Saas, i.e. a single scalable application in the cloud,
 		but I use it as a hosting environment for complete servers.
 	</p>
 
@@ -5143,7 +5141,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 
 	<p>
 		If you plan to use EC2 to follow this howto,
-		then familiarise yourself with EC2 first.
+		then familiarize yourself with EC2 first.
 		Check the <a href="#ec2_links">links</a> further down,
 		e.g. <a href="/docs/ec2/">my tips</a>.
 	</p>
@@ -5155,12 +5153,12 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 	<h5>Instance size</h5>
 	<p>
 		I run my own instances on several AWS ec2 micro size as my traffic is low.
-		However the memory is too low so I also add an 2GB EBS as swap file,
+		However the memory is too low so I also add a 2GB EBS as swap file,
 		detailed in my <a href="/docs/ec2/ubuntu/">Ubuntu ec2 guide</a>.
 	</p>
 	<p>
-		However for a medium company I recommend the small size.
-		High traffic servers needs perhaps larger instances.
+		However for a medium sized company I recommend the small size.
+		High traffic servers perhaps need larger instances.
 	</p>
 
 	<h5>Security and backup</h5>
@@ -5169,18 +5167,18 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 		if the server goes down.
 	</p>
 	<p>
-		When using EC2 images, be aware of security groups as they restricts
+		When using EC2 images, be aware of security groups as they restrict
 		access to your server on top of the firewall.
 		Initially you will need SSH (22) access, quite soon you will need SMTP
-		and IMAP ports opened, 25,143,465,587 and 993, and
-		eventually web server ports of 80 and 443.
+		and IMAP ports opened (25, 143, 465, 587 and 993) and
+		eventually web server ports (80 and 443).
 		<a href="http://developer.amazonwebservices.com/connect/entry.jspa?externalID=1233&categoryID=100G">Read here</a> for tips on securing AMIs.
 	</p>
 	<p>
 		Also do not terminate your instances without backing up your machine.
-		This you can do by either create your own image.
-		Or backup certain data if you got an image to instantiate from.
-		Back up to S3 or your local machine.
+		This you can do by either creating your own image
+		or backing up certain data if you got an image to instantiate from.
+		Backup to S3 or your local machine.
 		Create images only now and then. Backup configurations, database, maildirs
 		more regularly.
 	</p>
@@ -5194,17 +5192,17 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 		(Including other people using this howto.)
 		But Spamhaus has a simple web page to remove ips,
 		which they link to in rejection messages.
-		Simple look in your logs, click on the link on follow the instructions:
-		basically fill in your ip, email and state its for a mail server.
+		Simply look in your logs, click on the link and follow the instructions:
+		basically fill in your ip, email and state it's for a mail server.
 		Then Spamhaus will remove your IP from their database.
 	</p>
 	<p>
 		<b>2nd Note</b>:
-		Amazon AWS do have ec2 based email server limitations,
+		Amazon AWS does have ec2 based email server limitations,
 		so if you have a busy mail server, follow their
 		<a href="http://aws.amazon.com/ec2/faqs/#Are_there_any_limitations_in_sending_email_from_EC2_instances">
 		FAQ entry for removing mail throttling</a>.
-		AWS will then also add a reverse IP lookup for you elastic IP to your server,
+		AWS will then also add a reverse IP lookup for your elastic IP to your server,
 		which also helps in the spam scoring and delivery.
 	</p>
 
@@ -5339,7 +5337,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 		Please participate in the forums.<br/>
 		<ul>
 			<li><p>If you see an issue you also have, contribute with more information.</p></li>
-			<li><p>And even better if it something you may know how to solve, please <a href="http://ubuntuforums.org/showthread.php?t=185913">let people know</a>.</p></li>
+			<li><p>And even better if it is something you may know how to solve, please <a href="http://ubuntuforums.org/showthread.php?t=185913">let people know</a>.</p></li>
 			<li><p>And especially, if you post a problem, then solve it, let <a href="http://ubuntuforums.org/showthread.php?t=185913">people know what the solution was</a>! (and not just that you solved it...)</p></li>
 		</ul>
 	</p>
@@ -5349,7 +5347,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 	<p>
 		I am a firm believer in: <i><a href="http://www.amatecon.com/fish.html">Give a man a fish; you have fed him for today.
 		Teach a man to fish; and you have fed him for a lifetime</a></i>.<br/>
-		(Playing far too much <a href="http://www.civilization.com">Civilization</a> in my youth was not all wasted..)
+		(Playing far too much <a href="http://www.civilization.com">Civilization</a> in my youth was not all wasted...)
 		<br/>
 		Or rather my version:
 		<b>"Teach a man to fish, share the teaching,
@@ -5360,16 +5358,16 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 	<h4>Checklist</h4>
 
 	<p>
-		Before posting in the forums, ServerFault, etc, have you?:
+		Before posting in the forums, ServerFault, etc, have you:
 	</p>
 	<ul>
 		<li><p>
 			Read this document properly? Followed it step by step?<br/>
-			(While we can not insist on the same setup for everyone,
-			assistance is easier and more likely if less customised)
+			(While we cannot insist on the same setup for everyone,
+			assistance is easier and more likely if less customized)
 		</p></li>
 		<li><p>
-			Have <b>tested properly</b>?
+			<b>Tested properly</b>?
 			Applied the solutions provided in the <a href="#test">test section</a>?
 		</p></li>
 		<li><p>
@@ -5389,7 +5387,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 
 	<p>
 		When you do post remember to include a short dump of the mail.log.<br/>
-		(Remember to anonymise the server names, email addresses &amp; definitely passwords!)
+		(Remember to anonymize the server names, email addresses &amp; definitely passwords!)
 	</p>
 
 	<h6><a href="#top">Return to top</a>.</h6>
@@ -5402,7 +5400,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 		I do run a consultancy service, <a href="http://www.eray.co.uk">eray by flurdy</a>.
 		However I do not offer email server consultancy,
 		as it is not really my expertise nor interest despite this document.
-		It was a long time ago when I write most of this stuff.
+		It was a long time ago when I wrote most of this stuff.
 	</p>
 	<p>
 		I do though offer a complete <a href="http://aws.amazon.com">AWS</a> based email server set up by me.
@@ -5434,8 +5432,8 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 			<a href="http://ubuntuforums.org/showthread.php?t=185913">please use the forum</a>.
 		</p></li>
 		<li><p>
-			Please do <b>not</b> contact me if you have set up problems.
-			I am terrible procrastinator of replying to all emails,
+			Please do <b>not</b> contact me if you have setup problems.
+			I am a terrible procrastinator of replying to all emails,
 			even the very polite ones where I might even know the simple solution to. :(<br/>
 			Note that:
 			<ul>
@@ -5496,8 +5494,8 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 
 	<h5>Minor enhancements</h5>
 	<p>
-		If you any minor changes that will improve this document,
-		or update it with a more update to date information:
+		If you have any minor changes that will improve this document,
+		or if you have more up to date information:
 		Please fork <a href="https://github.com/flurdy/flurdy.com-docs">github.com/flurdy/flurdy.com-docs</a>
 		and send me a <a href="https://help.github.com/articles/using-pull-requests">pull request</a>.
 	</p>
@@ -5510,9 +5508,9 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 		Together we may then decide:
 	</p>
 	<ul>
-		<li><p>it is a good idea, and you should send me a <a href="https://github.com/flurdy/flurdy.com-docs">pull request</a></p></li>
-		<li><p>or it is independent enough to host it elsewhere and just send me a <a href="https://github.com/flurdy/flurdy.com-docs">pull request</a> with the link instead</p></li>
-		<li><p>or decide it is not beneficial and have a beer instead</p></li>
+		<li><p>it is a good idea, and you should send me a <a href="https://github.com/flurdy/flurdy.com-docs">pull request</a>,</p></li>
+		<li><p>or it is independent enough to host it elsewhere and just send me a <a href="https://github.com/flurdy/flurdy.com-docs">pull request</a> with the link instead,</p></li>
+		<li><p>or it is not beneficial and we have a beer instead.</p></li>
 	</ul>
 
 	<h5>Related HOWTOs</h5>
@@ -5524,7 +5522,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 		Please <a href="/contact">contact me</a> about your document or even better send me a <a href="https://github.com/flurdy/flurdy.com-docs">pull request</a> with the link added to this document.
 	</p>
 	<p>
-		If you require assistance with hosting it, please <a href="/contact">contact me</a> for suggestion or assistance.
+		If you require assistance with hosting it, please <a href="/contact">contact me</a> for suggestions or assistance.
 	</p>
 
 
@@ -5560,27 +5558,27 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 		users and domain as you'd like,
 		be as restrictive or open about security, virus, spam,
 		file sizes etc as you prefer.
-		And is it is well known, frequently updated, open source application stack,
+		And it is well known, frequently updated, open source application stack,
 		you can also trust the software you use.
 	</p>
 	<p>
-		And its your data. You and your data is not a product of another company.
-		In theory should make your data more secure and keep your privacy.
+		And it's your data. You and your data are not a product of another company.
+		In theory that should make your data more secure and keep your privacy.
 	</p>
 	<h4>Why I wrote this howto</h4>
 	<p>
 		When I set up my first email server I used a mix
 		of other howtos on the net.
-		And they were so helpful that I though I would
+		And they were so helpful that I thought I would
 		contribute back with my experience.
 		And it has been useful as a recipe script for
 		myself every time I need to install/update a server.
 	</p>
 	<p>
 		A less angelic reason is that back in 2003 I was setting up one mail server
-		for a myself and few friends and colleagues.
-		Soon I was getting more request for more servers,
-		and being a lazy programmer, I thought..
+		for myself and a few friends and colleagues.
+		Soon I was getting more requests for more servers,
+		and being a lazy programmer, I thought
 		"Why don't I write a howto and let them do it themselves..."
 		Soon it was listed on postfix.org
 		and I was getting thousands of hits and
@@ -5646,7 +5644,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 	<p>
 		Please refer to a <a href="edition5.html#app_links">previous edition</a>
 		for a list of urls and suitable downloads.
-		However most are unnecessary with decent package manager.
+		However most are unnecessary with a decent package manager.
 	</p>
 
 
@@ -5772,7 +5770,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 	</p>
 
 	<p>
-		Some question that frequently get sent to me, which first of all should have been asked in <a href="http://ubuntuforums.org/showthread.php?t=185913">the forums</a> and has been answered there many times, which then I tend to ignore are:
+		Some questions that frequently get sent to me, which first of all should have been asked in <a href="http://ubuntuforums.org/showthread.php?t=185913">the forums</a> and have been answered there many times, which then I tend to ignore are:
 	</p>
 
 	<ul>
@@ -5793,7 +5791,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 				</p></li>
 				<li><p>
 					<b>Have they ever received an email?</b><br/>
-					If not they can not log into squirrelmail
+					If not they cannot log into squirrelmail
 					as the email folders will not yet exist.
 				</p></li>
 				<li><p>
@@ -5815,7 +5813,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 			<ul>
 				<li><p>
 					<b>Have they received an email?</b><br/>
-					If not they you can not log into squirrelmail
+					If not then they cannot log into squirrelmail
 					as the email folders will not yet exist.
 					When receiving their first email,
 					postfix will create all the necessary folders.
@@ -5832,11 +5830,11 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 		<li>
 			<h5>SASL authentication does not work</h5>
 			<p>
-				All lot of people have issues with SASL in certain setups.
-				There are quite a few <a href="#forums">messages in the forum</a> is regarding this.
+				A lot of people have issues with SASL in certain setups.
+				There are quite a few <a href="#forums">messages in the forum</a> regarding this.
 			</p>
 			<p>
-				SASL works for me, but I can not tell my configuration apart
+				SASL works for me, but I cannot tell my configuration apart
 				from other people's server where it does not.
 			</p>
 			<p>
@@ -5864,7 +5862,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 			</ul>
 			<p>
 				Note however most people assume SASL is the problem
-				when another factor that is the root cause.
+				when another factor is the root cause.
 			</p>
 		</li>
 		<li>
@@ -5872,7 +5870,7 @@ ACCEPT		net		$FW		tcp		<i>1092</i></code>
 			<p>Running postfix on a micro instance on Amazon ec2?</p>
 			<p>
 				It only has 600Mb of ram and amavisd+clamav can grow too big over time.
-				Restart these services, and even some times reboot...
+				Restart these services, and even sometimes reboot...
 			</p>
 		</li>
 	</ul>


### PR DESCRIPTION
Your Postfix guide has been extremely helpful to me for many years, probably since the 10th edition (for Ubuntu 10.04). To give something back, I have checked the complete text of the current (14th) edition for spelling, grammar and punctuation mistakes.

You seem to be using both American and British spelling for some words. I prefer the British variants because I learnt/learned those at school, but for software documentation the American variants are probably more common, so I went with those.

There are some small mistakes in the HTML code and some of the sentences are a little weird, but I thought it might be better to put that in a separate pull request later. Please let me know if this is helpful at all, because it is also my first pull request ever. Thank you for keeping the guide up to date all these years!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flurdy/flurdy.com-docs/10)
<!-- Reviewable:end -->
