### PR TITLE
postfix doc: add dovecot-lmtp, sieve, managesieve

### DIFF
--- a/postfix/edition14.html
+++ b/postfix/edition14.html
@@ -222,6 +222,7 @@ src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
 					<li><p><a href="#ext_admin">Admin software</a></p></li>
 					<li><p><a href="#ext_gmail">Google Apps / GMail</a></p></li>
 					<li><p><a href="#ext_maildrop">Maildrop, spam folder and vacation messaging</a></p></li>
+					<li><p><a href="#ext_dovecot_lmtp_sieve">Dovecot LMTP and Pigeonhole Sieve, spam folder and mail filtering</a></p></li>
 					<li><p><a href="#ext_squirrel">SquirrelMail webmail client</a></p></li>
 					<li><p><a href="#ext_brute">Brute Force</a><p>
 						<ul>
@@ -4876,6 +4877,19 @@ sudo service postfix restart;</code>
 	</p>
 	<p>
 		Please <a href="http://ubuntuforums.org/showpost.php?p=7278296&postcount=223">read his post here</a>.
+	</p>
+<h6><a href="#top">Return to top</a>.</h6>
+
+
+	<a name="ext_dovecot_lmtp_sieve"></a>
+	<h3>Dovecot LMTP and Pigeonhole Sieve, spam folder and mail filtering</h3>
+	<p>
+		Sven M&auml;der has written an extension to this guide (with the <a href="#config-imap-dovecot">Dovecot extension</a>)
+		swapping in Dovecot LMTP for virtual transport and automatically delivering spam to a Junk or Spam folder using Dovecot's Pigeonhole Sieve plugin.
+		It also includes instructions to enable the managesieve protocol and allow to create sieve mail filter scripts in the Roundcube webmail interface.
+	</p>
+	<p>
+		Please <a href="https://rda.ch/dovecot-lmtp-sieve/">follow his guide here</a>.
 	</p>
 <h6><a href="#top">Return to top</a>.</h6>
 


### PR DESCRIPTION
Adds a link to an external guide hosted on my server to extend the dovecot setup with:

- virtual delivery via dovecot-lmtp
- global mail filtering (spam folder) using dovecot-sieve
- roundcube integration (user filters) using dovecot-managesieved

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flurdy/flurdy.com-docs/11)
<!-- Reviewable:end -->
