### PR TITLE
updated to libclamav9

### DIFF
--- a/postfix/edition15.html
+++ b/postfix/edition15.html
@@ -2084,7 +2084,7 @@ $final_spam_destiny = D_DISCARD; <span class="comment"># ubuntu default, recomme
 	<h5>ClamAV</h5>
 	<p>Installation:</p>
 	<p>
-		<code>sudo apt-get install clamav clamav-base libclamav7 clamav-daemon clamav-freshclam</code>
+		<code>sudo apt-get install clamav clamav-base libclamav9 clamav-daemon clamav-freshclam</code>
 		(Earlier vesions of Ubuntu may use libclamav5 or libclam6)
 	</p>
 	<p>


### PR DESCRIPTION
running a recent version of Ubuntu 20.04, the requirement seems to be libclamav9

I also wonder... is there no extra command to setup and/or start some clamav-related daemon?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flurdy/flurdy.com-docs/18)
<!-- Reviewable:end -->
